### PR TITLE
[chore] Tailwind v4 @theme CSS Variables 및 폰트 설정 #2

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>dayfolio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Chiron+GoRound+TC:wght@200..900&family=Dongle&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,18 @@
 function App() {
-  return <div>dayfolio</div>
+  return (
+    <div className="min-h-screen bg-bg text-ink font-body p-8">
+      <h1 className="font-display text-4xl mb-4">dayfolio</h1>
+      <p className="text-ink-muted mb-6">Tailwind v4 @theme 동작 확인</p>
+      <div className="flex gap-3">
+        <div className="bg-accent text-surface px-4 py-2 rounded-md">accent</div>
+        <div className="bg-surface-alt text-ink px-4 py-2 rounded-md border border-border">
+          surface-alt
+        </div>
+        <div className="bg-accent-soft text-accent px-4 py-2 rounded-md">accent-soft</div>
+      </div>
+      <p className="font-mono text-ink-faint mt-4">2026-04-02</p>
+    </div>
+  )
 }
 
 export default App

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,35 @@
 @import 'tailwindcss';
+
+@theme {
+  /* 배경 — 종이 질감 */
+  --color-bg: #f7f4d5;
+  --color-surface: #fdfcec;
+  --color-surface-alt: #ede9c4;
+
+  /* 잉크 */
+  --color-ink: #0a3323;
+  --color-ink-muted: #526b5e;
+  --color-ink-faint: #a8b8a0;
+
+  /* 포인트 — Moss Green */
+  --color-accent: #839958;
+  --color-accent-soft: #eef0e0;
+  --color-accent-hover: #105666;
+
+  /* 상태 */
+  --color-done: #839958;
+  --color-miss: #d3968c;
+
+  /* 보더 */
+  --color-border: #d5d1b8;
+
+  /* 폰트 */
+  --font-display: 'Chiron GoRound TC', sans-serif;
+  --font-body: 'Chiron GoRound TC', sans-serif;
+  --font-mono: 'Dongle', sans-serif;
+
+  /* 반경 */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #2

## 📝 변경 사항

- `src/styles/global.css`에 `@theme` 블록으로 디자인 토큰 전체 등록
  - 컬러 팔레트 (bg, surface, ink, accent, 상태, border)
  - 폰트 변수 (display, body, mono)
  - border-radius 변수 (sm, md, lg)
- **Water Lily 팔레트** 기반 색상 시스템 적용
  - `--color-bg: #F7F4D5` — 파피루스/베이지 계열 배경
  - `--color-accent: #839958` — Moss Green 포인트
  - `--color-miss: #D3968C` — Rosy Brown (미완료 상태)
  - `--color-accent-hover: #105666` — Midnight Green
- **폰트 교체**
  - display/body: `Chiron GoRound TC` (weight 200~900)
  - mono: `Dongle` (숫자, 날짜 포인트용)
- `index.html`에 Google Fonts CDN 링크 추가
- `src/App.tsx`에 Tailwind 유틸리티 동작 확인용 테스트 마크업 추가

## 💡 구현 메모

- Tailwind v4는 `tailwind.config.js` 없이 `@theme {}` 블록만으로 커스텀 토큰 등록 가능
- 등록된 변수는 즉시 유틸리티 클래스로 사용 가능 (`bg-accent`, `text-ink-muted` 등)
- `Chiron GoRound TC`는 한글 지원 + weight 범위가 넓어 display/body 겸용에 적합
- `Dongle`은 독특한 둥근 느낌으로 숫자/날짜 포인트 요소에만 제한적으로 사용

## 📸 스크린샷

| Before | After |
| ------ | ----- |
| 기본 Vite 보일러플레이트 | @theme 컬러·폰트 적용된 테스트 화면 |
