### PR TITLE
[style] global.css — CSS reset, @layer components, 노이즈 패턴 #3

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,3 +33,76 @@
   --radius-md: 12px;
   --radius-lg: 20px;
 }
+
+/* CSS Reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-ink);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+button {
+  cursor: pointer;
+  background: none;
+  border: none;
+  font: inherit;
+}
+
+input,
+textarea {
+  font: inherit;
+}
+
+/* 배경 노이즈 패턴 */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.03;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 128px 128px;
+}
+
+#root {
+  position: relative;
+  z-index: 1;
+}
+
+@layer components {
+  .card {
+    background-color: var(--color-surface);
+    border-radius: var(--radius-md);
+    box-shadow:
+      0 1px 3px rgba(10, 51, 35, 0.08),
+      0 0 0 0.5px var(--color-border);
+  }
+
+  .divider-dashed {
+    border: none;
+    border-top: 1px dashed var(--color-border);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #3

## 📝 변경 사항

- **CSS Reset** — `box-sizing: border-box`, `margin/padding: 0`, `body` 기본 스타일 (font, color, line-height, antialiased)
- **배경 노이즈 패턴** — `body::before`에 SVG `fractalNoise` 패턴 적용 (opacity 0.03). 종이 질감 분위기 연출
- **`@layer components`** — 재사용 공통 컴포넌트 스타일 등록
  - `.card` — surface 배경 + rounded-md + 미세 그림자 + 0.5px 보더
  - `.divider-dashed` — dashed 구분선 (노트 느낌)
- **`#root` z-index 분리** — 노이즈 레이어(z-index: 0) 위에 콘텐츠(z-index: 1) 보장

## 💡 구현 메모

- 노이즈 패턴은 `position: fixed`로 전체 화면 고정, `pointer-events: none`으로 인터랙션 차단
- `.card` 그림자는 `rgba(10, 51, 35, 0.08)` — ink 컬러 기반으로 따뜻한 그린 톤 유지
- `button`, `input`, `textarea` reset 포함 — 브라우저 기본 스타일 제거

## 📸 스크린샷

| Before | After |
| ------ | ----- |
| 기본 브라우저 스타일 | reset + 노이즈 패턴 적용 |
