### PR TITLE
[feat] types/index.ts — 전체 타입 정의 #4

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,40 @@
+/** 카테고리 */
+export interface Category {
+  id: string // uuid
+  name: string // "건강", "학습"
+  color: string // hex, --color-accent 계열
+  icon?: string // 이모지 "🌿"
+}
+
+/** 습관 */
+export interface Habit {
+  id: string // uuid
+  name: string
+  categoryId: string // Category.id 참조
+  tags: string[]
+  reminderTime?: string // "08:00" | undefined
+  order: number // 정렬 순서
+  createdAt: string // ISO 8601
+  archivedAt?: string // 보관된 습관
+}
+
+/** 하루 기록 */
+export interface DayRecord {
+  date: string // "2026-04-01" (키)
+  note: string
+  mood: 1 | 2 | 3 | 4 | 5 | null // 1=최저 5=최고
+  sleepHours: number | null // 0.5 단위, 0~12
+  checkIns: {
+    [habitId: string]: boolean
+  }
+}
+
+/** localStorage 전체 구조 */
+export interface AppStorage {
+  version: number
+  categories: Category[]
+  habits: Habit[]
+  records: {
+    [date: string]: DayRecord // "2026-04-01": DayRecord
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #4

## 📝 변경 사항

`src/types/index.ts` 신규 생성 — 앱 전체에서 사용하는 TypeScript 인터페이스 정의

| 타입 | 설명 |
|------|------|
| `Category` | id, name, color(hex), icon?(이모지) |
| `Habit` | id, name, categoryId, tags, reminderTime?, order, createdAt, archivedAt? |
| `DayRecord` | date, note, mood(1\~5\|null), sleepHours(0.5단위\|null), checkIns |
| `AppStorage` | version, categories, habits, records(date → DayRecord 맵) |

## 💡 구현 메모

- `DayRecord.mood`는 `1 | 2 | 3 | 4 | 5 | null` 유니온 타입 — 숫자 범위를 타입 레벨에서 강제
- `checkIns`는 `{ [habitId: string]: boolean }` 맵 — 날짜별 습관 체크 여부
- `AppStorage.records`는 `{ [date: string]: DayRecord }` 맵 — `"2026-04-01"` ISO 키 기준
- 모든 인터페이스 `export` — store, lib, components에서 바로 import 가능

## 📸 스크린샷

해당 없음 (타입 정의만)
