### PR TITLE
[feat] lib/storage.ts — localStorage 연동 #5

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,54 @@
+import type { AppStorage } from '../types'
+
+const STORAGE_KEY = 'dayfolio-v1'
+const CURRENT_VERSION = 1
+
+function defaultStorage(): AppStorage {
+  return {
+    version: CURRENT_VERSION,
+    categories: [],
+    habits: [],
+    records: {},
+  }
+}
+
+export function loadStorage(): AppStorage {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultStorage()
+
+    const parsed: unknown = JSON.parse(raw)
+    return migrate(parsed, CURRENT_VERSION)
+  } catch {
+    return defaultStorage()
+  }
+}
+
+export function saveStorage(data: AppStorage): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch {
+    // localStorage 쓰기 실패 (용량 초과 등) — 무시
+  }
+}
+
+export function migrate(old: unknown, toVersion: number): AppStorage {
+  if (!isObject(old)) return defaultStorage()
+
+  const version = typeof old.version === 'number' ? old.version : 0
+
+  if (version === toVersion) {
+    return old as AppStorage
+  }
+
+  // v0 → v1: 최초 마이그레이션 (기존 데이터 없는 경우)
+  if (version < 1 && toVersion >= 1) {
+    return defaultStorage()
+  }
+
+  return old as AppStorage
+}
+
+function isObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val)
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #5

## 📝 변경 사항

`src/lib/storage.ts` 신규 생성 — localStorage 읽기/쓰기/마이그레이션 유틸

| 함수 | 설명 |
|------|------|
| `loadStorage()` | localStorage에서 읽기. 없거나 파싱 실패 시 기본값 반환 |
| `saveStorage(data)` | AppStorage를 JSON 직렬화해 저장. 쓰기 실패는 무시 |
| `migrate(old, toVersion)` | 버전 불일치 시 마이그레이션. v0→v1은 기본값으로 초기화 |

## 💡 구현 메모

- 스토리지 키: `dayfolio-v1` (상수 `STORAGE_KEY`)
- `loadStorage`는 `try/catch`로 감싸 — JSON 파싱 에러, localStorage 접근 불가(Private 모드 등) 상황 대응
- `migrate`는 `isObject` 가드로 unknown 타입 안전하게 처리
- 컴포넌트/store에서 직접 `localStorage` 접근 금지 — 반드시 이 유틸 경유

## 📸 스크린샷

해당 없음 (유틸 함수)
