### PR TITLE
[feat] lib/date.ts — date-fns 날짜 유틸 #6

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,17 @@
+import { format, parseISO, startOfMonth, endOfMonth, eachDayOfInterval } from 'date-fns'
+
+/** 오늘 날짜를 "yyyy-MM-dd" 형식으로 반환 */
+export const today = (): string => format(new Date(), 'yyyy-MM-dd')
+
+/** Date → "yyyy-MM-dd" 키 */
+export const toDateKey = (date: Date): string => format(date, 'yyyy-MM-dd')
+
+/** "yyyy-MM-dd" 키 → Date */
+export const fromDateKey = (key: string): Date => parseISO(key)
+
+/** 특정 월의 모든 날짜 키 배열 반환 */
+export const getDaysInMonth = (year: number, month: number): string[] =>
+  eachDayOfInterval({
+    start: startOfMonth(new Date(year, month - 1)),
+    end: endOfMonth(new Date(year, month - 1)),
+  }).map(toDateKey)


### PR DESCRIPTION
## 🔗 관련 이슈

closes #6

## 📝 변경 사항

`src/lib/date.ts` 신규 생성 — date-fns 기반 날짜 유틸 함수

| 함수 | 반환 | 설명 |
|------|------|------|
| `today()` | `string` | 오늘 날짜 `"yyyy-MM-dd"` |
| `toDateKey(date)` | `string` | `Date` → `"yyyy-MM-dd"` |
| `fromDateKey(key)` | `Date` | `"yyyy-MM-dd"` → `Date` |
| `getDaysInMonth(year, month)` | `string[]` | 해당 월 전체 날짜 키 배열 |

## 💡 구현 메모

- `new Date()` 직접 사용 금지 규칙에 따라 모든 날짜 처리는 이 유틸 경유
- `getDaysInMonth`의 month 파라미터는 1-based (1월=1, 12월=12)
- `fromDateKey`는 `parseISO` 사용 — 로컬 타임존 이슈 없이 안전하게 파싱

## 📸 스크린샷

해당 없음 (유틸 함수)
