### PR TITLE
[feat] store/habitStore.ts — Zustand 단일 스토어 구현 #7

### DIFF
--- a/src/store/habitStore.ts
+++ b/src/store/habitStore.ts
@@ -1,0 +1,196 @@
+import { create } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
+import { v4 as uuidv4 } from 'uuid'
+import type { Category, Habit, DayRecord, AppStorage } from '../types'
+import { loadStorage, saveStorage } from '../lib/storage'
+import { today, getDaysInMonth } from '../lib/date'
+
+interface HabitStore {
+  // 상태
+  categories: Category[]
+  habits: Habit[]
+  records: Record<string, DayRecord>
+
+  // 습관 CRUD
+  addHabit: (habit: Omit<Habit, 'id' | 'createdAt' | 'order'>) => void
+  updateHabit: (id: string, updates: Partial<Habit>) => void
+  archiveHabit: (id: string) => void
+  reorderHabits: (ids: string[]) => void
+
+  // 카테고리 CRUD
+  addCategory: (category: Omit<Category, 'id'>) => void
+  updateCategory: (id: string, updates: Partial<Category>) => void
+  deleteCategory: (id: string) => void
+
+  // 하루 기록
+  toggleCheckIn: (date: string, habitId: string) => void
+  updateNote: (date: string, note: string) => void
+  updateMood: (date: string, mood: DayRecord['mood']) => void
+  updateSleep: (date: string, hours: number | null) => void
+
+  // 셀렉터
+  getDayRecord: (date: string) => DayRecord
+  getMonthRecords: (year: number, month: number) => Record<string, DayRecord>
+  getStreak: (habitId: string) => { current: number; best: number }
+  getMonthScore: (habitId: string, year: number, month: number) => number
+}
+
+function emptyDayRecord(date: string): DayRecord {
+  return { date, note: '', mood: null, sleepHours: null, checkIns: {} }
+}
+
+const initial = loadStorage()
+
+export const useHabitStore = create<HabitStore>()(
+  subscribeWithSelector((set, get) => ({
+    categories: initial.categories,
+    habits: initial.habits,
+    records: initial.records,
+
+    // 습관 CRUD
+    addHabit: (habit) =>
+      set((s) => ({
+        habits: [
+          ...s.habits,
+          {
+            ...habit,
+            id: uuidv4(),
+            createdAt: new Date().toISOString(),
+            order: s.habits.length,
+          },
+        ],
+      })),
+
+    updateHabit: (id, updates) =>
+      set((s) => ({
+        habits: s.habits.map((h) => (h.id === id ? { ...h, ...updates } : h)),
+      })),
+
+    archiveHabit: (id) =>
+      set((s) => ({
+        habits: s.habits.map((h) =>
+          h.id === id ? { ...h, archivedAt: new Date().toISOString() } : h
+        ),
+      })),
+
+    reorderHabits: (ids) =>
+      set((s) => ({
+        habits: ids
+          .map((id, order) => {
+            const habit = s.habits.find((h) => h.id === id)
+            return habit ? { ...habit, order } : null
+          })
+          .filter((h): h is Habit => h !== null),
+      })),
+
+    // 카테고리 CRUD
+    addCategory: (category) =>
+      set((s) => ({
+        categories: [...s.categories, { ...category, id: uuidv4() }],
+      })),
+
+    updateCategory: (id, updates) =>
+      set((s) => ({
+        categories: s.categories.map((c) => (c.id === id ? { ...c, ...updates } : c)),
+      })),
+
+    deleteCategory: (id) =>
+      set((s) => ({
+        categories: s.categories.filter((c) => c.id !== id),
+        habits: s.habits.map((h) =>
+          h.categoryId === id ? { ...h, categoryId: '' } : h
+        ),
+      })),
+
+    // 하루 기록
+    toggleCheckIn: (date, habitId) =>
+      set((s) => {
+        const prev = s.records[date] ?? emptyDayRecord(date)
+        return {
+          records: {
+            ...s.records,
+            [date]: {
+              ...prev,
+              checkIns: { ...prev.checkIns, [habitId]: !prev.checkIns[habitId] },
+            },
+          },
+        }
+      }),
+
+    updateNote: (date, note) =>
+      set((s) => {
+        const prev = s.records[date] ?? emptyDayRecord(date)
+        return { records: { ...s.records, [date]: { ...prev, note } } }
+      }),
+
+    updateMood: (date, mood) =>
+      set((s) => {
+        const prev = s.records[date] ?? emptyDayRecord(date)
+        return { records: { ...s.records, [date]: { ...prev, mood } } }
+      }),
+
+    updateSleep: (date, hours) =>
+      set((s) => {
+        const prev = s.records[date] ?? emptyDayRecord(date)
+        return { records: { ...s.records, [date]: { ...prev, sleepHours: hours } } }
+      }),
+
+    // 셀렉터
+    getDayRecord: (date) => get().records[date] ?? emptyDayRecord(date),
+
+    getMonthRecords: (year, month) => {
+      const keys = getDaysInMonth(year, month)
+      const { records } = get()
+      return Object.fromEntries(
+        keys.map((key) => [key, records[key] ?? emptyDayRecord(key)])
+      )
+    },
+
+    getStreak: (habitId) => {
+      const { records } = get()
+      const todayKey = today()
+      const sortedKeys = Object.keys(records).sort()
+
+      let current = 0
+      let best = 0
+      let streak = 0
+
+      for (const key of sortedKeys) {
+        if (records[key].checkIns[habitId]) {
+          streak += 1
+          if (streak > best) best = streak
+          if (key === todayKey) current = streak
+        } else {
+          if (key < todayKey) streak = 0
+        }
+      }
+
+      // 오늘 체크 안 했으면 어제까지 기준
+      if (!records[todayKey]?.checkIns[habitId]) {
+        current = streak
+      }
+
+      return { current, best }
+    },
+
+    getMonthScore: (habitId, year, month) => {
+      const monthRecords = get().getMonthRecords(year, month)
+      const days = Object.keys(monthRecords)
+      if (days.length === 0) return 0
+
+      const done = days.filter((d) => monthRecords[d].checkIns[habitId]).length
+      return Math.round((done / days.length) * 100)
+    },
+  }))
+)
+
+// localStorage 자동 저장
+useHabitStore.subscribe((state) => {
+  const data: AppStorage = {
+    version: 1,
+    categories: state.categories,
+    habits: state.habits,
+    records: state.records,
+  }
+  saveStorage(data)
+})


### PR DESCRIPTION
## 🔗 관련 이슈

closes #7

## 📝 변경 사항

`src/store/habitStore.ts` 신규 생성 — 앱 전체 상태를 관리하는 Zustand 단일 스토어

**습관 CRUD**
- `addHabit` — uuid 자동 생성, order는 현재 배열 길이로 설정
- `updateHabit` — id 기준 부분 업데이트
- `archiveHabit` — `archivedAt` 타임스탬프 설정 (완전 삭제 없음)
- `reorderHabits` — id 배열 순서대로 order 재부여

**카테고리 CRUD**
- `addCategory`, `updateCategory`, `deleteCategory`
- 카테고리 삭제 시 연관 습관의 `categoryId`를 `''`으로 초기화

**하루 기록**
- `toggleCheckIn` — 해당 날짜 기록 없으면 빈 레코드 생성 후 토글
- `updateNote`, `updateMood`, `updateSleep` — 동일 패턴

**셀렉터**
- `getDayRecord` — 없으면 빈 레코드 반환
- `getMonthRecords` — 해당 월 전체 날짜 키로 레코드 맵 반환
- `getStreak` — 현재/최고 스트릭 계산 (오늘 미체크 시 어제까지 기준)
- `getMonthScore` — 달성률 0~100 정수 반환

**localStorage 자동 저장**
- `subscribeWithSelector`로 state 변경 감지 → `saveStorage` 호출

## 💡 구현 메모

- `emptyDayRecord` 헬퍼로 빈 레코드 생성 일관성 유지
- `loadStorage()`로 초기 상태 복원 — 새로고침 후에도 데이터 유지
- Today ↔ Monthly 양쪽이 동일한 store를 바라보므로 별도 동기화 불필요

## 📸 스크린샷

해당 없음 (스토어 로직)
