### PR TITLE
feat(ui): CheckCircle 원형 체크 버튼 컴포넌트 구현

### DIFF
--- a/src/components/ui/CheckCircle/index.tsx
+++ b/src/components/ui/CheckCircle/index.tsx
@@ -1,0 +1,63 @@
+import { motion, useReducedMotion } from 'motion/react'
+
+interface CheckCircleProps {
+  done: boolean
+  onToggle: () => void
+  size?: number
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 8L6.5 11.5L13 4.5"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function CheckCircle({ done, onToggle, size = 32 }: CheckCircleProps) {
+  const shouldReduceMotion = useReducedMotion()
+
+  const springTransition = {
+    type: 'spring' as const,
+    stiffness: 400,
+    damping: 15,
+  }
+
+  const tapAnimation = shouldReduceMotion ? {} : { scale: 1.2 }
+  const animateState = shouldReduceMotion
+    ? { scale: 1 }
+    : { scale: done ? [1, 1.2, 1] : 1 }
+
+  return (
+    <motion.button
+      onClick={onToggle}
+      animate={animateState}
+      whileTap={tapAnimation}
+      transition={springTransition}
+      aria-pressed={done}
+      aria-label={done ? '체크 해제' : '체크'}
+      style={{ width: size, height: size }}
+      className={[
+        'rounded-full flex items-center justify-center flex-shrink-0',
+        done
+          ? 'bg-done'
+          : 'bg-transparent border-2 border-ink-faint',
+      ].join(' ')}
+    >
+      {done && <CheckIcon />}
+    </motion.button>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #8

## 📝 변경 사항

습관 체크인에 사용하는 원형 버튼 컴포넌트를 구현했습니다.
done/undone 상태를 토글하며, 탭 시 spring 애니메이션으로 피드백을 제공합니다.

## 💡 구현 메모

- `useReducedMotion()` 훅으로 `prefers-reduced-motion` 대응 — 감소 모션 설정 시 scale 애니메이션 전체 비활성화
- `animate` prop에 keyframe 배열(`[1, 1.2, 1]`)을 사용해 done 상태 전환 시 튀는 느낌 구현
- 체크 아이콘은 인라인 SVG로 처리 — 외부 아이콘 라이브러리 의존성 없음
- `aria-pressed`, `aria-label` 접근성 속성 포함

## 📸 스크린샷

| Before | After |
| ------ | ----- |
| 미구현 | `undone`: 빈 원형 테두리 / `done`: 그린 fill + 흰색 체크 아이콘 + spring 애니메이션 |