### PR TITLE
feat(ui): PageTransition 화면 전환 Motion 래퍼 구현

### DIFF
--- a/src/components/ui/PageTransition/index.tsx
+++ b/src/components/ui/PageTransition/index.tsx
@@ -1,0 +1,35 @@
+import { motion, useReducedMotion } from 'motion/react'
+
+interface PageTransitionProps {
+  children: React.ReactNode
+}
+
+const fullVariants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: 8 },
+}
+
+const reducedVariants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+}
+
+export default function PageTransition({ children }: PageTransitionProps) {
+  const shouldReduceMotion = useReducedMotion()
+  const variants = shouldReduceMotion ? reducedVariants : fullVariants
+
+  return (
+    <motion.div
+      variants={variants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      className="w-full"
+    >
+      {children}
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #9

## 📝 변경 사항

모든 페이지 전환에 사용할 fade + translateY(8px) Motion 래퍼 컴포넌트를 구현했습니다.
`AnimatePresence`와 함께 사용하면 페이지 진입/이탈 시 자연스러운 전환 효과가 적용됩니다.

## 💡 구현 메모

- `fullVariants` / `reducedVariants` 두 가지 variants를 분리해 `useReducedMotion()` 결과에 따라 분기
  - 감소 모션 설정 시: y 이동 없이 opacity 전환만 수행
- `exit` variant를 포함해 `AnimatePresence`로 감싸는 쪽에서 key만 넘겨주면 바로 동작하도록 구성
- transition: duration 0.2s, ease 'easeOut'

## 📸 스크린샷

| Before | After |
| ------ | ----- |
| 미구현 | 페이지 진입 시 fade + y 8px 슬라이드업 (200ms easeOut) |