### PR TITLE
feat(ui): BottomNav 하단 탭 네비게이션 구현

### DIFF
--- a/src/components/ui/BottomNav/index.tsx
+++ b/src/components/ui/BottomNav/index.tsx
@@ -1,0 +1,133 @@
+import { NavLink } from 'react-router';
+
+interface NavItem {
+  to: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+function TodayIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="3" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <circle cx="12" cy="15" r="1.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function MonthlyIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="3" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="7" y1="13" x2="9" y2="13" />
+      <line x1="11" y1="13" x2="13" y2="13" />
+      <line x1="15" y1="13" x2="17" y2="13" />
+      <line x1="7" y1="17" x2="9" y2="17" />
+      <line x1="11" y1="17" x2="13" y2="17" />
+      <line x1="15" y1="17" x2="17" y2="17" />
+    </svg>
+  );
+}
+
+function StatsIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="3" y1="20" x2="21" y2="20" />
+      <rect x="5" y="13" width="3" height="7" rx="1" />
+      <rect x="10.5" y="8" width="3" height="12" rx="1" />
+      <rect x="16" y="4" width="3" height="16" rx="1" />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { to: '/', label: 'Today', icon: <TodayIcon /> },
+  { to: '/monthly', label: 'Monthly', icon: <MonthlyIcon /> },
+  { to: '/stats', label: 'Stats', icon: <StatsIcon /> },
+  { to: '/settings', label: 'Settings', icon: <SettingsIcon /> },
+];
+
+export default function BottomNav() {
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 bg-surface border-t border-border"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <ul className="flex items-stretch h-16">
+        {NAV_ITEMS.map(({ to, label, icon }) => (
+          <li key={to} className="flex-1">
+            <NavLink
+              to={to}
+              end={to === '/'}
+              className={({ isActive }) =>
+                [
+                  'flex flex-col items-center justify-center gap-1 w-full h-full transition-colors duration-150',
+                  isActive ? 'text-accent' : 'text-ink-muted',
+                ].join(' ')
+              }
+              aria-label={label}
+            >
+              {icon}
+              <span className="text-xs font-body leading-none">{label}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #10

## 📝 변경 사항

Today / Monthly / Stats / Settings 4개 탭으로 구성된 하단 고정 네비게이션 컴포넌트를 구현했습니다.
React Router `NavLink`로 활성 탭을 자동으로 하이라이트합니다.

## 💡 구현 메모

- `NAV_ITEMS` 배열로 탭 정보를 선언하고 루프 렌더링 — 탭 추가/변경 시 배열만 수정하면 됨
- Today 탭(`/`)에 `end={true}` 옵션 적용 — `/monthly` 등 하위 경로에서 Today가 같이 활성화되는 문제 방지
- safe-area-inset 대응: `style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}` 인라인 적용 (iOS 홈 인디케이터 영역 확보)
- 아이콘 4종 모두 인라인 SVG (24×24, stroke 방식) — 외부 아이콘 라이브러리 의존성 없음

## 📸 스크린샷

| Before | After |
| ------ | ----- |
| 미구현 | 하단 고정 4탭 네비게이션, 활성 탭 `text-accent` 강조 |