### PR TITLE
feat(today): 라우트 구조 + Today 페이지 MVP 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,24 @@
-function App() {
+import { Outlet, useLocation } from 'react-router'
+import { AnimatePresence } from 'motion/react'
+import BottomNav from './components/ui/BottomNav'
+import PageTransition from './components/ui/PageTransition'
+
+export default function App() {
+  const location = useLocation()
+
   return (
-    <div className="min-h-screen bg-bg text-ink font-body p-8">
-      <h1 className="font-display text-4xl mb-4">dayfolio</h1>
-      <p className="text-ink-muted mb-6">Tailwind v4 @theme 동작 확인</p>
-      <div className="flex gap-3">
-        <div className="bg-accent text-surface px-4 py-2 rounded-md">accent</div>
-        <div className="bg-surface-alt text-ink px-4 py-2 rounded-md border border-border">
-          surface-alt
-        </div>
-        <div className="bg-accent-soft text-accent px-4 py-2 rounded-md">accent-soft</div>
-      </div>
-      <p className="font-mono text-ink-faint mt-4">2026-04-02</p>
+    <div
+      className="min-h-screen bg-bg text-ink font-body flex flex-col items-center"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
+      <main className="pb-24 w-full max-w-md">
+        <AnimatePresence mode="wait">
+          <PageTransition key={location.pathname}>
+            <Outlet />
+          </PageTransition>
+        </AnimatePresence>
+      </main>
+      <BottomNav />
     </div>
   )
 }
-
-export default App

--- a/src/components/today/CategoryFilter/index.tsx
+++ b/src/components/today/CategoryFilter/index.tsx
@@ -1,0 +1,38 @@
+import { useHabitStore } from '../../../store/habitStore'
+import type { Category } from '../../../types'
+
+interface CategoryFilterProps {
+  selectedCategoryId: string | null
+  onChange: (categoryId: string | null) => void
+}
+
+export default function CategoryFilter({ selectedCategoryId, onChange }: CategoryFilterProps) {
+  const categories = useHabitStore((s) => s.categories)
+
+  const baseClass =
+    'px-4 py-2 rounded-full text-sm font-body transition-colors whitespace-nowrap min-h-[36px]'
+  const selectedClass = 'bg-accent-soft text-accent'
+  const unselectedClass = 'bg-surface text-ink-muted hover:text-ink'
+
+  return (
+    <div className="flex gap-2 overflow-x-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <button
+        type="button"
+        className={`${baseClass} ${selectedCategoryId === null ? selectedClass : unselectedClass}`}
+        onClick={() => onChange(null)}
+      >
+        전체
+      </button>
+      {categories.map((category: Category) => (
+        <button
+          key={category.id}
+          type="button"
+          className={`${baseClass} ${selectedCategoryId === category.id ? selectedClass : unselectedClass}`}
+          onClick={() => onChange(category.id)}
+        >
+          {category.icon ? `${category.icon} ` : ''}{category.name}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/today/DailyNote/index.tsx
+++ b/src/components/today/DailyNote/index.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react'
+import { useHabitStore } from '../../../store/habitStore'
+import { today } from '../../../lib/date'
+
+export default function DailyNote() {
+  const todayKey = today()
+  const note = useHabitStore((s) => s.records[todayKey]?.note ?? '')
+  const updateNote = useHabitStore((s) => s.updateNote)
+
+  const [draft, setDraft] = useState(note)
+
+  useEffect(() => {
+    setDraft(note)
+  }, [note])
+
+  function commit() {
+    if (draft !== note) {
+      updateNote(todayKey, draft)
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur()
+    } else if (e.key === 'Escape') {
+      setDraft(note)
+      e.currentTarget.blur()
+    }
+  }
+
+  return (
+    <input
+      type="text"
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={handleKeyDown}
+      placeholder="오늘 하루를 한 줄로..."
+      className="w-full py-3 px-4 rounded-md bg-surface font-body text-ink text-sm leading-relaxed outline-none placeholder:text-ink-faint"
+    />
+  )
+}

--- a/src/components/today/DateHeader/index.tsx
+++ b/src/components/today/DateHeader/index.tsx
@@ -1,0 +1,21 @@
+import { format } from 'date-fns'
+import { Link } from 'react-router'
+import { today, fromDateKey } from '../../../lib/date'
+
+export default function DateHeader() {
+  const dateLabel = format(fromDateKey(today()), 'MMMM d')
+
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="text-3xl sm:text-4xl font-display text-accent-hover leading-none">
+        {dateLabel}
+      </span>
+      <Link
+        to="/monthly"
+        className="text-ink-muted text-sm font-body hover:text-accent transition-colors py-2 px-2 -mr-2 inline-flex items-center whitespace-nowrap"
+      >
+        Monthly →
+      </Link>
+    </div>
+  )
+}

--- a/src/components/today/HabitItem/index.tsx
+++ b/src/components/today/HabitItem/index.tsx
@@ -1,0 +1,45 @@
+import { motion, useReducedMotion } from 'motion/react'
+import { CheckCircle } from '../../ui/CheckCircle'
+import type { Habit } from '../../../types'
+
+interface HabitItemProps {
+  habit: Habit
+  done: boolean
+  onToggle: () => void
+  index: number
+}
+
+export default function HabitItem({ habit, done, onToggle, index }: HabitItemProps) {
+  const shouldReduceMotion = useReducedMotion()
+
+  const initial = shouldReduceMotion
+    ? { opacity: 0 }
+    : { opacity: 0, y: 8 }
+
+  const animate = shouldReduceMotion
+    ? { opacity: 1 }
+    : { opacity: 1, y: 0 }
+
+  const transition = shouldReduceMotion
+    ? { duration: 0.25, ease: 'easeOut' as const }
+    : { delay: index * 0.05, duration: 0.25, ease: 'easeOut' as const }
+
+  return (
+    <motion.li
+      initial={initial}
+      animate={animate}
+      transition={transition}
+      className="flex items-center gap-3 py-3"
+    >
+      <CheckCircle done={done} onToggle={onToggle} size={24} />
+      <span
+        className={[
+          'font-body text-ink flex-1',
+          done ? 'line-through text-ink-muted' : '',
+        ].join(' ').trim()}
+      >
+        {habit.name}
+      </span>
+    </motion.li>
+  )
+}

--- a/src/components/today/HabitList/index.tsx
+++ b/src/components/today/HabitList/index.tsx
@@ -1,0 +1,39 @@
+import { useHabitStore } from '../../../store/habitStore'
+import { today } from '../../../lib/date'
+import HabitItem from '../HabitItem'
+
+interface HabitListProps {
+  selectedCategoryId: string | null
+}
+
+export default function HabitList({ selectedCategoryId }: HabitListProps) {
+  const todayKey = today()
+  const habits = useHabitStore((s) => s.habits)
+  const toggleCheckIn = useHabitStore((s) => s.toggleCheckIn)
+  const checkIns = useHabitStore((s) => s.records[todayKey]?.checkIns)
+
+  const filtered = habits
+    .filter((h) => !h.archivedAt)
+    .filter((h) => selectedCategoryId === null || h.categoryId === selectedCategoryId)
+    .sort((a, b) => a.order - b.order)
+
+  if (filtered.length === 0) {
+    return (
+      <p className="text-ink-muted text-sm py-6 text-center">습관이 없습니다</p>
+    )
+  }
+
+  return (
+    <ul>
+      {filtered.map((habit, index) => (
+        <HabitItem
+          key={habit.id}
+          habit={habit}
+          done={checkIns?.[habit.id] ?? false}
+          onToggle={() => toggleCheckIn(todayKey, habit.id)}
+          index={index}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/src/components/today/MoodPicker/index.tsx
+++ b/src/components/today/MoodPicker/index.tsx
@@ -1,0 +1,59 @@
+import { useHabitStore } from '../../../store/habitStore'
+import { today } from '../../../lib/date'
+import type { DayRecord } from '../../../types'
+
+interface MoodOption {
+  value: 1 | 2 | 3 | 4 | 5
+  emoji: string
+}
+
+const MOOD_OPTIONS: MoodOption[] = [
+  { value: 1, emoji: '😞' },
+  { value: 2, emoji: '😐' },
+  { value: 3, emoji: '😊' },
+  { value: 4, emoji: '😄' },
+  { value: 5, emoji: '😁' },
+]
+
+export default function MoodPicker() {
+  const todayKey = today()
+  const mood = useHabitStore((s) => s.getDayRecord(todayKey).mood)
+  const updateMood = useHabitStore((s) => s.updateMood)
+
+  function handleSelect(value: DayRecord['mood']) {
+    if (mood === value) {
+      updateMood(todayKey, null)
+    } else {
+      updateMood(todayKey, value)
+    }
+  }
+
+  return (
+    <div>
+      <span className="text-ink-muted text-sm font-body">오늘 기분</span>
+      <div className="flex gap-3 mt-3 justify-between">
+        {MOOD_OPTIONS.map(({ value, emoji }) => {
+          const isSelected = mood === value
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => handleSelect(value)}
+              aria-label={`기분 ${value}단계`}
+              aria-pressed={isSelected}
+              style={{ fontSize: '40px', lineHeight: 1 }}
+              className={[
+                'w-14 h-14 rounded-full flex items-center justify-center transition-all duration-200',
+                isSelected
+                  ? 'bg-accent-soft scale-110 grayscale-0'
+                  : 'bg-transparent hover:bg-surface-alt grayscale opacity-60 hover:opacity-100 hover:grayscale-0',
+              ].join(' ')}
+            >
+              {emoji}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/today/SleepSlider/index.tsx
+++ b/src/components/today/SleepSlider/index.tsx
@@ -1,0 +1,34 @@
+import { useHabitStore } from '../../../store/habitStore'
+import { today } from '../../../lib/date'
+import './sleep-slider.css'
+
+export default function SleepSlider() {
+  const todayKey = today()
+  const sleepHours = useHabitStore((s) => s.getDayRecord(todayKey).sleepHours)
+  const updateSleep = useHabitStore((s) => s.updateSleep)
+
+  const displayValue = sleepHours !== null ? `${sleepHours}h` : '—'
+  const sliderValue = sleepHours !== null ? sleepHours : 0
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    updateSleep(todayKey, Number(e.target.value))
+  }
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-ink-muted text-sm font-body">수면</span>
+        <span className="font-mono text-ink">{displayValue}</span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={12}
+        step={0.5}
+        value={sliderValue}
+        onChange={handleChange}
+        className="sleep-slider w-full"
+      />
+    </div>
+  )
+}

--- a/src/components/today/SleepSlider/sleep-slider.css
+++ b/src/components/today/SleepSlider/sleep-slider.css
@@ -1,0 +1,29 @@
+input[type="range"].sleep-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 9999px;
+  background: var(--color-ink-faint);
+  outline: none;
+  cursor: pointer;
+}
+
+input[type="range"].sleep-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: var(--color-accent);
+  cursor: pointer;
+  border: none;
+}
+
+input[type="range"].sleep-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: var(--color-accent);
+  cursor: pointer;
+  border: none;
+}

--- a/src/components/ui/BottomNav/index.tsx
+++ b/src/components/ui/BottomNav/index.tsx
@@ -108,7 +108,7 @@ export default function BottomNav() {
       className="fixed bottom-0 left-0 right-0 bg-surface border-t border-border"
       style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
     >
-      <ul className="flex items-stretch h-16">
+      <ul className="flex items-stretch h-16 max-w-md mx-auto">
         {NAV_ITEMS.map(({ to, label, icon }) => (
           <li key={to} className="flex-1">
             <NavLink

--- a/src/components/ui/CheckCircle/index.tsx
+++ b/src/components/ui/CheckCircle/index.tsx
@@ -6,58 +6,67 @@ interface CheckCircleProps {
   size?: number
 }
 
-function CheckIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-    >
-      <path
-        d="M3 8L6.5 11.5L13 4.5"
-        stroke="white"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
-
-export function CheckCircle({ done, onToggle, size = 32 }: CheckCircleProps) {
+export function CheckCircle({ done, onToggle, size = 24 }: CheckCircleProps) {
   const shouldReduceMotion = useReducedMotion()
 
-  const springTransition = {
+  const spring = {
     type: 'spring' as const,
-    stiffness: 400,
-    damping: 15,
+    stiffness: 500,
+    damping: 22,
   }
-
-  const tapAnimation = shouldReduceMotion ? {} : { scale: 1.2 }
-  const animateState = shouldReduceMotion
-    ? { scale: 1 }
-    : { scale: done ? [1, 1.2, 1] : 1 }
 
   return (
     <motion.button
+      type="button"
       onClick={onToggle}
-      animate={animateState}
-      whileTap={tapAnimation}
-      transition={springTransition}
+      whileTap={shouldReduceMotion ? undefined : { scale: 0.88 }}
+      transition={spring}
       aria-pressed={done}
       aria-label={done ? '체크 해제' : '체크'}
       style={{ width: size, height: size }}
-      className={[
-        'rounded-full flex items-center justify-center flex-shrink-0',
-        done
-          ? 'bg-done'
-          : 'bg-transparent border-2 border-ink-faint',
-      ].join(' ')}
+      className="relative rounded-full flex items-center justify-center flex-shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
     >
-      {done && <CheckIcon />}
+      {/* 바깥 링 — 항상 존재, done 상태에 따라 색 전환 */}
+      <motion.span
+        aria-hidden="true"
+        className="absolute inset-0 rounded-full border-[1.5px]"
+        animate={{
+          borderColor: done
+            ? 'var(--color-accent)'
+            : 'var(--color-ink-faint)',
+          backgroundColor: done
+            ? 'var(--color-accent)'
+            : 'var(--color-surface)',
+        }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+      />
+
+      {/* 체크 아이콘 */}
+      <motion.svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        className="relative z-10 text-surface"
+        style={{ width: size * 0.5, height: size * 0.5 }}
+        initial={false}
+        animate={
+          shouldReduceMotion
+            ? { opacity: done ? 1 : 0 }
+            : { opacity: done ? 1 : 0, scale: done ? 1 : 0.4 }
+        }
+        transition={spring}
+      >
+        <motion.path
+          d="M5 12.5 L10 17.5 L19 7.5"
+          strokeWidth={2.6}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          initial={false}
+          animate={{ pathLength: done ? 1 : 0 }}
+          transition={{ duration: 0.35, ease: 'easeOut', delay: done ? 0.05 : 0 }}
+        />
+      </motion.svg>
     </motion.button>
   )
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -4,10 +4,56 @@ const STORAGE_KEY = 'dayfolio-v1'
 const CURRENT_VERSION = 1
 
 function defaultStorage(): AppStorage {
+  const now = new Date().toISOString()
   return {
     version: CURRENT_VERSION,
-    categories: [],
-    habits: [],
+    categories: [
+      { id: 'cat-health', name: '건강', color: '#839958', icon: '🌿' },
+      { id: 'cat-learn', name: '학습', color: '#839958', icon: '📚' },
+      { id: 'cat-mind', name: '마음', color: '#839958', icon: '🧘' },
+    ],
+    habits: [
+      {
+        id: 'habit-water',
+        name: '물 2L 마시기',
+        categoryId: 'cat-health',
+        tags: [],
+        order: 0,
+        createdAt: now,
+      },
+      {
+        id: 'habit-walk',
+        name: '30분 산책',
+        categoryId: 'cat-health',
+        tags: [],
+        order: 1,
+        createdAt: now,
+      },
+      {
+        id: 'habit-read',
+        name: '독서 20페이지',
+        categoryId: 'cat-learn',
+        tags: [],
+        order: 2,
+        createdAt: now,
+      },
+      {
+        id: 'habit-english',
+        name: '영어 단어 10개',
+        categoryId: 'cat-learn',
+        tags: [],
+        order: 3,
+        createdAt: now,
+      },
+      {
+        id: 'habit-meditate',
+        name: '명상 10분',
+        categoryId: 'cat-mind',
+        tags: [],
+        order: 4,
+        createdAt: now,
+      },
+    ],
     records: {},
   }
 }
@@ -38,7 +84,7 @@ export function migrate(old: unknown, toVersion: number): AppStorage {
   const version = typeof old.version === 'number' ? old.version : 0
 
   if (version === toVersion) {
-    return old as AppStorage
+    return old as unknown as AppStorage
   }
 
   // v0 → v1: 최초 마이그레이션 (기존 데이터 없는 경우)
@@ -46,7 +92,7 @@ export function migrate(old: unknown, toVersion: number): AppStorage {
     return defaultStorage()
   }
 
-  return old as AppStorage
+  return old as unknown as AppStorage
 }
 
 function isObject(val: unknown): val is Record<string, unknown> {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router'
+import { router } from './router'
 import './styles/global.css'
-import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>
 )

--- a/src/pages/Monthly/index.tsx
+++ b/src/pages/Monthly/index.tsx
@@ -1,0 +1,7 @@
+export default function MonthlyPage() {
+  return (
+    <div className="px-4 sm:px-6 pt-5 sm:pt-8 pb-6">
+      <p className="font-display text-2xl">Monthly</p>
+    </div>
+  )
+}

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router'
+
+export default function NotFoundPage() {
+  return (
+    <div className="px-4 sm:px-6 py-16 text-center">
+      <p className="font-display text-4xl mb-2">404</p>
+      <p className="text-ink-muted mb-6">페이지를 찾을 수 없습니다</p>
+      <Link to="/" className="text-accent underline underline-offset-4">
+        Today로 돌아가기
+      </Link>
+    </div>
+  )
+}

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,0 +1,7 @@
+export default function SettingsPage() {
+  return (
+    <div className="px-4 sm:px-6 pt-5 sm:pt-8 pb-6">
+      <p className="font-display text-2xl">Settings</p>
+    </div>
+  )
+}

--- a/src/pages/Stats/index.tsx
+++ b/src/pages/Stats/index.tsx
@@ -1,0 +1,7 @@
+export default function StatsPage() {
+  return (
+    <div className="px-4 sm:px-6 pt-5 sm:pt-8 pb-6">
+      <p className="font-display text-2xl">Stats</p>
+    </div>
+  )
+}

--- a/src/pages/Today/index.tsx
+++ b/src/pages/Today/index.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import DateHeader from '../../components/today/DateHeader'
+import DailyNote from '../../components/today/DailyNote'
+import CategoryFilter from '../../components/today/CategoryFilter'
+import HabitList from '../../components/today/HabitList'
+import MoodPicker from '../../components/today/MoodPicker'
+import SleepSlider from '../../components/today/SleepSlider'
+
+export default function TodayPage() {
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
+
+  return (
+    <div className="px-4 sm:px-6 pt-10 sm:pt-14 pb-10 space-y-7 sm:space-y-9">
+      <DateHeader />
+      <DailyNote />
+      <div className="space-y-4">
+        <CategoryFilter
+          selectedCategoryId={selectedCategoryId}
+          onChange={setSelectedCategoryId}
+        />
+        <HabitList selectedCategoryId={selectedCategoryId} />
+      </div>
+      <div className="pt-6 border-t border-dashed border-ink-faint space-y-7">
+        <MoodPicker />
+        <SleepSlider />
+      </div>
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,21 @@
+import { createBrowserRouter } from 'react-router'
+import RootLayout from './App'
+import TodayPage from './pages/Today'
+import MonthlyPage from './pages/Monthly'
+import StatsPage from './pages/Stats'
+import SettingsPage from './pages/Settings'
+import NotFoundPage from './pages/NotFound'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    Component: RootLayout,
+    children: [
+      { index: true, Component: TodayPage },
+      { path: 'monthly', Component: MonthlyPage },
+      { path: 'stats', Component: StatsPage },
+      { path: 'settings', Component: SettingsPage },
+      { path: '*', Component: NotFoundPage },
+    ],
+  },
+])

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,7 +14,7 @@
   /* 포인트 — Moss Green */
   --color-accent: #839958;
   --color-accent-soft: #eef0e0;
-  --color-accent-hover: #105666;
+  --color-accent-hover: #105656;
 
   /* 상태 */
   --color-done: #839958;
@@ -32,15 +32,6 @@
   --radius-sm: 6px;
   --radius-md: 12px;
   --radius-lg: 20px;
-}
-
-/* CSS Reset */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 html {
@@ -65,7 +56,6 @@ svg {
 button {
   cursor: pointer;
   background: none;
-  border: none;
   font: inherit;
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈

closes #11
closes #12
closes #13
closes #14
closes #15
closes #16
closes #17

## 📝 변경 사항

React Router v7 기반 라우트/레이아웃 뼈대를 세우고, Today 페이지의 MVP 섹션 6개를 모두 구현했습니다.

### 라우트 & 레이아웃 (#11)
- `createBrowserRouter`로 `/`, `/monthly`, `/stats`, `/settings`, 404 라우트 정의
- `App.tsx`가 `<Outlet />`을 `AnimatePresence` + `PageTransition`으로 감싸 페이지 전환 애니메이션 제공
- flex 기반 중앙 정렬 + `safe-area-inset-top` 대응
- `BottomNav`의 내부 `<ul>`에 `max-w-md mx-auto` 적용 (데스크탑에서 탭 정렬 유지)

### Today 서브 컴포넌트
- **DateHeader (#12)** — `date-fns` "MMMM d", `font-display` + `text-accent-hover`, `Link to="/monthly"` 서브 네비
- **DailyNote (#13)** — 항상 `<input>` 렌더(토글 제거)로 포커스 전후 동일한 레이아웃, Enter/Escape/blur 커밋, `records[todayKey]?.note` 직접 구독
- **CategoryFilter (#14)** — 전체 + 카테고리 태그 버튼, 선택 시 `bg-accent-soft`, 가로 스크롤 + 스크롤바 숨김
- **HabitList / HabitItem (#15)** — `motion` 기반 staggered reveal, `CheckCircle` 통합, 카테고리 필터 + `order` 정렬, 아카이브 제외, 빈 상태 메시지
- **MoodPicker (#16)** — 이모지 5종. 미선택은 `grayscale + opacity-60`, 선택은 `bg-accent-soft + scale-110 + grayscale 해제`. 재클릭 해제
- **SleepSlider (#17)** — `input[type=range]` 0~12h / 0.5h step, `var(--color-accent)` 트랙 커스텀 CSS

### 크로스 커팅
- **CheckCircle 리뉴얼** — `motion` 링/배경 컬러 전환 + `pathLength` 드로잉 애니메이션, `focus-visible` 링, 기본 size 24
- **global.css 리셋 정리** — Tailwind preflight와 중복되는 `*` 리셋 제거(`padding/margin` 충돌 해결), `button { border: none }` 제거(`border-2`가 먹도록), `--color-accent-hover` `#105666` → `#105656`
- **storage.ts** — 첫 실행 시 기본 카테고리 3종(건강/학습/마음) + 습관 5종 시드, `migrate`의 `as AppStorage` 캐스트 TS2352 수정

## 💡 구현 메모

- **Zustand 리렌더 함정**: `HabitList`와 `DailyNote`가 처음엔 `getDayRecord` 함수를 셀렉터로 구독했는데, 함수 참조는 불변이라 `records` 변경을 감지 못해 토글/메모 반영이 누락됐습니다. `records[todayKey]?.X`를 직접 구독하는 패턴으로 교정.
- **중앙 정렬**: 처음에는 각 페이지에 `max-w-md mx-auto`를 걸었는데 실제 렌더링에서 왼쪽 정렬이 되는 환경이 있어, 센터링을 `App.tsx`의 `flex flex-col items-center`로 레이아웃 레벨로 올렸습니다. 페이지는 자기 패딩만 신경 쓰면 됩니다.
- **Tailwind preflight 충돌**: 기본 CSS 리셋 블록(`* { margin: 0; padding: 0 }` 및 `button { border: none }`)이 Tailwind v4 preflight와 충돌해 유틸리티 클래스가 시각적으로 무력화되는 현상이 있었습니다. 리셋은 preflight에 위임.
- **커밋 단위**: 이슈별 원자 커밋으로 분리했습니다. 리뷰/롤백 용이.

## 📸 스크린샷

| Before | After |
| ------ | ----- |
| (빈 Vite 템플릿) | Today 페이지 6개 섹션 렌더링 / 반응형 중앙 정렬 / BottomNav 4탭 전환 |

### 로컬 검증
- `pnpm build` ✅
- `pnpm lint` ✅
- 브라우저 UI 검증은 PR 작성자가 로컬에서 확인